### PR TITLE
BNFIR-4780: Attempt to resolve google python client library conflict with pyparsing version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyparsing>=2.4.0
+pyparsing>=2.4.2,<=2.4.7

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ from setuptools import setup
 setup(
     name='plyse',
     setup_requires = [
-    'pyparsing>=2.4.0',
+    'pyparsing>=2.4.2,<=2.4.7',
     ],
     install_requires = [
-    'pyparsing>=2.4.0',
+    'pyparsing>=2.4.2,<=2.4.7',
     ],
     version='1.0.3',
     url='https://github.com/sebastiandev/plyse',


### PR DESCRIPTION
1. https://barracudacorp.sharepoint.com/:x:/s/IPIRteam/EXe2uRGCk1lJiDaYQ0jXwIEBVFXalK9Ujb6pVLnEqnlgxA?e=8aN4PQ - **version matrix**

2. added lower and upper limit for pyparsing version constraint, since we are using operatorPrecedence fn which is not available post 2.4.7